### PR TITLE
Consider .tar as a regular compression mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 # Changelog
+## [V1.3.2]()(2018-11-7)
+**Fixed bugs**
+Add tar as regular extension ( null compressor method )
 ## [V1.3.1]()(2018-10-13)
 **Fixed bugs**
 - Verify if the pv package is present on the Linux system

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Henri Devigne',
     author_email='henri.devigne@bonkgaming.fr',
     url='https://github.com/henri9813/tar-progress',
-    version='1.3.1',
+    version='1.3.2',
     description="This utility offer a progress-bar to the GNU tar program, and provide it on Windows",
     long_description=long_description,
     packages=find_packages(),

--- a/tar_progress/classes/interface.py
+++ b/tar_progress/classes/interface.py
@@ -16,7 +16,8 @@ class Archiver(object):
         ".bz2": "bz2",
         ".xz": "xz",
         ".lzma": "xz",
-        ".lz": "xz"
+        ".lz": "xz",
+        ".tar": ""
     }
 
     def __init__(self):


### PR DESCRIPTION
Fixes: #11 

To have a code cleaner, i consider tar as a null regular compression method.

( better for loop etc ... )