### PR TITLE
Fix bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 - '3.7'

--- a/tar_progress/classes/linux.py
+++ b/tar_progress/classes/linux.py
@@ -29,10 +29,10 @@ class LinuxArchiver(Archiver):
     @classmethod
     def create(cls, filename, compression, sources):
         files = ' '.join(sources)
-        size = subprocess.check_output("du -sb --apparent-size --total "
+        size = str(int(subprocess.check_output("du -sb --apparent-size --total "
                                        + files
                                        + " | tail -n1 | awk '{printf $1}'",
-                                       shell=True)
+                                       shell=True)))
         if compression == "gz":
             command = "tar -cf - " + files + " | pv -s " + size + " | gzip > " + filename
         elif compression == "bz2":


### PR DESCRIPTION
When running tar-progress I had the following error:
Traceback (most recent call last):
  File "/home/user/.local/bin/tar-progress", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.9/site-packages/tar_progress/__main__.py", line 51, in main
    archiver.create(arguments.file, arguments.compressor, arguments.files)
  File "/home/user/.local/lib/python3.9/site-packages/tar_progress/classes/linux.py", line 38, in create
    command = "tar -cf - " + files + " | pv -s " + size + " | bzip2 > " + filename
TypeError: can only concatenate str (not "bytes") to str

Which arose since there is no implicit conversion between bytes and strings.